### PR TITLE
Integer timestamps support

### DIFF
--- a/src/DatabaseSettingStore.php
+++ b/src/DatabaseSettingStore.php
@@ -59,13 +59,6 @@ class DatabaseSettingStore extends SettingStore
 	protected $queryConstraint;
 
 	/**
-	 * Any columns that should be used to filter.
-	 *
-	 * @var array
-	 */
-	protected $filterColumns = array();
-
-	/**
 	 * Any extra columns that should be added to the rows.
 	 *
 	 * @var array
@@ -124,16 +117,6 @@ class DatabaseSettingStore extends SettingStore
 		$this->data = array();
 		$this->loaded = false;
 		$this->queryConstraint = $callback;
-	}
-
-	/**
-	 * Set columns to be used to filter
-	 *
-	 * @param array $columns
-	 */
-	public function setFilterColumns(array $columns)
-	{
-		$this->filterColumns = $columns;
 	}
 
 	/**
@@ -304,7 +287,7 @@ class DatabaseSettingStore extends SettingStore
 		$query = $this->connection->table($this->table);
 
 		if (!$insert) {
-			foreach ($this->filterColumns as $key => $value) {
+			foreach ($this->extraColumns as $key => $value) {
 				$query->where($key, '=', $value);
 			}
 		}

--- a/src/migrations/2015_08_25_172600_create_settings_table.php
+++ b/src/migrations/2015_08_25_172600_create_settings_table.php
@@ -18,6 +18,9 @@ class CreateSettingsTable extends Migration
 			$this->keyColumn = Config::get('anlutro/l4-settings::keyColumn');
 			$this->valueColumn = Config::get('anlutro/l4-settings::valueColumn');
 		}
+
+		$this->createdAtColumn = 'created_at';
+		$this->updatedAtColumn = 'updated_at';
 	}
 
 	/**
@@ -32,8 +35,8 @@ class CreateSettingsTable extends Migration
 			$table->increments('id');
 			$table->string($this->keyColumn)->index();
 			$table->text($this->valueColumn);
-			$table->integer('created_at');
-			$table->integer('updated_at');
+			$table->integer($this->createdAtColumn);
+			$table->integer($this->updatedAtColumn);
 		});
 	}
 

--- a/src/migrations/2015_08_25_172600_create_settings_table.php
+++ b/src/migrations/2015_08_25_172600_create_settings_table.php
@@ -32,6 +32,8 @@ class CreateSettingsTable extends Migration
 			$table->increments('id');
 			$table->string($this->keyColumn)->index();
 			$table->text($this->valueColumn);
+			$table->integer('created_at');
+			$table->integer('updated_at');
 		});
 	}
 


### PR DESCRIPTION
- Adds 2 columns `created_at` and `updated_at` timestamps in the table. The epoch values of time is stored in the database, hence, integers.
- Currently, `setExtraColumns` function not only sets the extra columns, but also adds a filter for each of the column while looking up the table. This PR separates out the 2 operations, with the functions `setExtraColumns` which can be used only to set the extra columns, and `setFilterColumns` which can be used to apply filters for a particular field while looking up in the table.