### PR TITLE
Adds date-time formatted timestamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
 language: php
 
 php: 
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,18 @@ php:
   - 7.1
   - 7.2
 
+matrix:
+  allow_failures:
+    - php: 7.2
+      env: COMPOSER_ARGS="--prefer-lowest"
+
 env:
   matrix:
     - COMPOSER_ARGS=""
     - COMPOSER_ARGS="--prefer-lowest"
 
 install:
-  - composer update ${COMPOSER_ARGS} --dev --no-interaction
+  - composer update ${COMPOSER_ARGS} --no-interaction
 
 script:
   - vendor/bin/phpunit --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
 
 env:
   matrix:
@@ -22,6 +23,6 @@ install:
   - composer update ${COMPOSER_ARGS} --dev --no-interaction
 
 script:
-  - phpunit --verbose
+  - vendor/bin/phpunit --verbose
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "illuminate/database": "Save settings to a database table."
     },
     "require-dev": {
+        "phpunit/phpunit": "4.*",
         "mockery/mockery": "0.9.*",
         "illuminate/database": ">=4.1 <6.0",
         "illuminate/filesystem": ">=4.1 <6.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/database": "Save settings to a database table."
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*",
+        "phpunit/phpunit": ">=4.8, <6",
         "mockery/mockery": "0.9.*",
         "illuminate/database": ">=4.1 <6.0",
         "illuminate/filesystem": ">=4.1 <6.0"

--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -140,7 +140,7 @@ abstract class SettingStore
 	 *
 	 * @param $force Force a reload of data. Default false.
 	 */
-	public function load($foce = false)
+	public function load($force = false)
 	{
 		if (!$this->loaded || $force) {
 			$this->data = $this->read();

--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -42,7 +42,7 @@ abstract class SettingStore
 	 */
 	public function get($key, $default = null)
 	{
-		$this->checkLoaded();
+		$this->load();
 
 		return ArrayUtil::get($this->data, $key, $default);
 	}
@@ -56,7 +56,7 @@ abstract class SettingStore
 	 */
 	public function has($key)
 	{
-		$this->checkLoaded();
+		$this->load();
 
 		return ArrayUtil::has($this->data, $key);
 	}
@@ -69,7 +69,7 @@ abstract class SettingStore
 	 */
 	public function set($key, $value = null)
 	{
-		$this->checkLoaded();
+		$this->load();
 		$this->unsaved = true;
 		
 		if (is_array($key)) {
@@ -113,7 +113,7 @@ abstract class SettingStore
 	 */
 	public function all()
 	{
-		$this->checkLoaded();
+		$this->load();
 
 		return $this->data;
 	}
@@ -136,11 +136,13 @@ abstract class SettingStore
 	}
 
 	/**
-	 * Check if the settings data has been loaded.
+	 * Make sure data is loaded.
+	 *
+	 * @param $force Force a reload of data. Default false.
 	 */
-	protected function checkLoaded()
+	public function load($foce = false)
 	{
-		if (!$this->loaded) {
+		if (!$this->loaded || $force) {
 			$this->data = $this->read();
 			$this->loaded = true;
 		}

--- a/src/migrations/2015_08_25_172600_create_settings_table.php
+++ b/src/migrations/2015_08_25_172600_create_settings_table.php
@@ -32,6 +32,8 @@ class CreateSettingsTable extends Migration
 			$table->increments('id');
 			$table->string($this->keyColumn)->index();
 			$table->text($this->valueColumn);
+			$table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));
+			$table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
 		});
 	}
 


### PR DESCRIPTION
- Adds 2 columns created_at and updated_at timestamps in the table. The values are stored in the database as timestamps, in the format `YYYY-MM-DD hh:mm:ss`.
- This PR implements the functionality of adding timestamps by adding `CURRENT_TIMESTAMP` and `CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP` in the table schema itself.