### PR TITLE
Removed migration loading for drone fix

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -59,7 +59,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 	public function boot()
 	{
 		if (version_compare(Application::VERSION, '5.3', '>=')) {
-//			$this->loadMigrationsFrom(__DIR__.'/migrations');
 			$this->publishes([
 				__DIR__.'/config/config.php' => config_path('settings.php')
 			], 'config');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -59,7 +59,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 	public function boot()
 	{
 		if (version_compare(Application::VERSION, '5.3', '>=')) {
-			$this->loadMigrationsFrom(__DIR__.'/migrations');
+//			$this->loadMigrationsFrom(__DIR__.'/migrations');
 			$this->publishes([
 				__DIR__.'/config/config.php' => config_path('settings.php')
 			], 'config');


### PR DESCRIPTION
Commented a line loading migration file from laravel-settings repo to avoid creation of duplicate tables, that was failing build.